### PR TITLE
Fix model load

### DIFF
--- a/hubnspoke/flnode/node1.py
+++ b/hubnspoke/flnode/node1.py
@@ -114,8 +114,9 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
 
         logger.info('received test request')
 
+        ma.load_model(headModelFile)
         response_data = Mapping()
-        response_data = ma.predict(class_names, headModelFile)
+        response_data = ma.predict(class_names)
 
         logger.info("sending test report to the Central Hub...")       
         buffer = BytesIO()

--- a/hubnspoke/flnode/node1.py
+++ b/hubnspoke/flnode/node1.py
@@ -48,6 +48,7 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
         if os.path.isfile(headModelFile):
             request_data.update(reply="model received")
             logger.info(f"global model saved at: {headModelFile}")
+            ma.load_model(headModelFile)
             logger.info("FL node is ready for training and waiting for training configurations")
         else:
             request_data.update(reply="error while receiving the model")

--- a/hubnspoke/flnode/node1_nii.py
+++ b/hubnspoke/flnode/node1_nii.py
@@ -114,8 +114,9 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
 
         logger.info('received test request')
 
+        ma.load_model(headModelFile)
         response_data = Mapping()
-        response_data = ma.predict(headModelFile)
+        response_data = ma.predict()
 
         logger.info("sending test report to the Central Hub...")       
         buffer = BytesIO()

--- a/hubnspoke/flnode/node1_nii.py
+++ b/hubnspoke/flnode/node1_nii.py
@@ -48,6 +48,7 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
         if os.path.isfile(headModelFile):
             request_data.update(reply="model received")
             logger.info(f"global model saved at: {headModelFile}")
+            ma.load_model(headModelFile)
             logger.info("FL node is ready for training and waiting for training configurations")
         else:
             request_data.update(reply="error while receiving the model")

--- a/hubnspoke/flnode/node2.py
+++ b/hubnspoke/flnode/node2.py
@@ -114,8 +114,9 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
 
         logger.info('received test request')
 
+        ma.load_model(headModelFile)
         response_data = Mapping()
-        response_data = ma.predict(class_names, headModelFile)
+        response_data = ma.predict(class_names)
 
         logger.info("sending test report to the Central Hub...")       
         buffer = BytesIO()

--- a/hubnspoke/flnode/node2.py
+++ b/hubnspoke/flnode/node2.py
@@ -48,6 +48,7 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
         if os.path.isfile(headModelFile):
             request_data.update(reply="model received")
             logger.info(f"global model saved at: {headModelFile}")
+            ma.load_model(headModelFile)
             logger.info("FL node is ready for training and waiting for training configurations")
         else:
             request_data.update(reply="error while receiving the model")

--- a/hubnspoke/flnode/node2_nii.py
+++ b/hubnspoke/flnode/node2_nii.py
@@ -114,8 +114,9 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
 
         logger.info('received test request')
 
+        ma.load_model(headModelFile)
         response_data = Mapping()
-        response_data = ma.predict(headModelFile)
+        response_data = ma.predict()
 
         logger.info("sending test report to the Central Hub...")       
         buffer = BytesIO()

--- a/hubnspoke/flnode/node2_nii.py
+++ b/hubnspoke/flnode/node2_nii.py
@@ -48,6 +48,7 @@ class MonaiFLService(monaifl_pb2_grpc.MonaiFLServiceServicer):
         if os.path.isfile(headModelFile):
             request_data.update(reply="model received")
             logger.info(f"global model saved at: {headModelFile}")
+            ma.load_model(headModelFile)
             logger.info("FL node is ready for training and waiting for training configurations")
         else:
             request_data.update(reply="error while receiving the model")

--- a/hubnspoke/flnode/pipeline/monaialgo.py
+++ b/hubnspoke/flnode/pipeline/monaialgo.py
@@ -113,10 +113,9 @@ class MonaiAlgo(Algo):
         pass
         # json.dump(model, path)
 
-    def predict(self, class_names, headModelFile):
+    def predict(self, class_names):
         set_determinism(seed=0)
         device = torch.device(DEVICE) 
-        self.load_model(headModelFile)
         self.model.to(device)
         self.model.eval()
 

--- a/hubnspoke/flnode/pipeline2/monaialgo_nii.py
+++ b/hubnspoke/flnode/pipeline2/monaialgo_nii.py
@@ -95,10 +95,9 @@ class MonaiAlgo(Algo):
         pass
         # json.dump(model, path)
 
-    def predict(self, headModelFile):
+    def predict(self):
         set_determinism(seed=0)
         device = torch.device(DEVICE)
-        self.load_model(headModelFile)
         self.model.to(device)
         self.model.eval()
 


### PR DESCRIPTION
In the first epoch, the weights sent by the hub were not loaded into MonaiAlgo object. Added the missing ma.load to fix it.
Besides that, to avoid the update of the local weights been dependent from the MonaiAlgo predict function, I proposed to move to the ReportTransfer method the model loading.